### PR TITLE
Fix 'Undefined variable: response' in HubSpot integration

### DIFF
--- a/src/integrations/types/HubSpot.php
+++ b/src/integrations/types/HubSpot.php
@@ -233,7 +233,7 @@ class HubSpot extends AbstractIntegrationType implements CrmTypeInterface
 
             } catch (RequestException $e) {
                 if ($e->getResponse()) {
-                    $json = \GuzzleHttp\json_decode((string) $response->getBody(), false);
+                    $json = \GuzzleHttp\json_decode((string) $e->getResponse()->getBody(), false);
                     if (isset($json->error, $json->identityProfile) && $json->error === 'CONTACT_EXISTS') {
                         $contactId = $json->identityProfile->vid;
                     } else {


### PR DESCRIPTION
Hi guys,

Just a small PR that fixes `Undefined variable: response` when creating a duplicate HubSpot contact.

The error lies on line 236.

Before:
`$json = \GuzzleHttp\json_decode((string) $response->getBody(), false);`

After:
`$json = \GuzzleHttp\json_decode((string) $e->getResponse()->getBody(), false);`

Thanks!