### PR TITLE
Fix required field validation with array values

### DIFF
--- a/src/decorators/Fields/RequiredFieldValidatorDecorator.php
+++ b/src/decorators/Fields/RequiredFieldValidatorDecorator.php
@@ -23,12 +23,24 @@ class RequiredFieldValidatorDecorator extends AbstractDecorator
     {
         $field = $event->getField();
 
+        if (!$field->isRequired()) {
+            return;
+        }
+
         if ($field instanceof File) {
             return;
         }
 
-        if ($field->isRequired() && empty(trim($field->getValue()))) {
-            $field->addValidationError('This field is required');
+        $value = $field->getValue();
+
+        if (!is_array($value)) {
+            $value = trim($value);
         }
+
+        if (!empty($value)) {
+            return;
+        }
+
+        $field->addValidationError('This field is required');
     }
 }


### PR DESCRIPTION
Me again,

I was encountering an error with the required field validation whereby if the value was an `array` it'd throw because `trim()` is expecting a `string`.

I have added some `array` type checking.

Cheers